### PR TITLE
Add compatibility with Sphinx 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - PYTHONFAULTHANDLER=x
     - PYTHONWARNINGS=all
 install:
-  - pip install -U pip setuptools tox flake8
+  - pip install -U pip tox flake8
   - pip install -r test-reqs.txt
 script:
   - flake8

--- a/sphinxcontrib/websupport/builder.py
+++ b/sphinxcontrib/websupport/builder.py
@@ -34,6 +34,7 @@ class WebSupportBuilder(PickleHTMLBuilder):
     name = 'websupport'
     versioning_method = 'commentable'
     versioning_compare = True  # for commentable node's uuid stability.
+    default_translator_class = WebSupportTranslator
 
     def init(self):
         # type: () -> None
@@ -53,11 +54,6 @@ class WebSupportBuilder(PickleHTMLBuilder):
         self.virtual_staticdir = virtual_staticdir
         self.search = search
         self.storage = storage
-
-    def init_translator_class(self):
-        # type: () -> None
-        if self.translator_class is None:
-            self.translator_class = WebSupportTranslator
 
     def prepare_writing(self, docnames):
         # type: (Iterable[unicode]) -> None

--- a/tests/test_websupport.py
+++ b/tests/test_websupport.py
@@ -15,7 +15,7 @@ from sphinx.websupport.errors import DocumentNotFoundError, \
 from sphinx.websupport.storage import StorageBackend
 from sphinx.websupport.storage.differ import CombinedHtmlDiff
 try:
-    from sphinx.websupport.storage.sqlalchemystorage import Session, \
+    from sphinxcontrib.websupport.storage.sqlalchemystorage import Session, \
         Comment, CommentVote
     from sphinx.websupport.storage.sqlalchemy_db import Node
     sqlalchemy_missing = False


### PR DESCRIPTION
- Replace `init_translator_class` method with `default_translator_class` attribute. The former has no effect in Sphinx 1.6, see sphinx-doc/sphinx@78ea36a. Cc @tk0miya.
- In `test_websupport.py`, replace import from `sphinx.websupport.storage.sqlalchemystorage` with import from <code>sphinx<strong>contrib</strong>.websupport.storage.sqlalchemystorage</code>. The former does not provide `Session`, `Comment` and `CommentVote`, it [provides only `SQLAlchemyStorage`](https://github.com/sphinx-doc/sphinx/blob/stable/sphinx/websupport/storage/sqlalchemystorage.py#L12). Without this change all tests get skipped. Please let me know if you want me to change all other imports as well.
- Make Travis builds pass by not trying to upgrade setuptools. The version which is installed on Travis by defaults cannot be uninstalled properly. It is a workaround for pypa/setuptools#1086.