### PR TITLE
Update pypi.python.org URL to pypi.org

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     name='sphinxcontrib-websupport',
     version=get_version(),
     url='http://sphinx-doc.org/',
-    download_url='https://pypi.python.org/pypi/sphinxcontrib-websupport',
+    download_url='https://pypi.org/project/sphinxcontrib-websupport/',
     license='BSD',
     author='Georg Brandl',
     author_email='georg@python.org',


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html