### PR TITLE
Include templates/searchresults.html in the source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,3 +6,4 @@ include tox.ini
 
 recursive-include tests *
 recursive-include sphinxcontrib/websupport/files *
+include sphinxcontrib/websupport/templates/*.html


### PR DESCRIPTION
The current tarball on PyPI does not include that file.