### PR TITLE
Import PickleHTMLBuilder from sphinxcontrib-serializinghtml package

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Release 1.2.4 (2020-08-09)
+==========================
+
+* Import PickleHTMLBuilder from sphinxcontrib-serializinghtml package
+
 Release 1.2.3 (2020-06-27)
 ==========================
 

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,9 @@ setup(
     python_requires=">=3.5",
     packages=find_packages(exclude=['tests']),
     include_package_data=True,
+    install_requires=[
+        'sphinxcontrib-serializinghtml',
+    ],
     extras_require=extras_require,
     entry_points={
         'sphinx.builders': [

--- a/sphinxcontrib/websupport/builder.py
+++ b/sphinxcontrib/websupport/builder.py
@@ -18,7 +18,7 @@ from docutils.io import StringOutput
 from sphinx import version_info as sphinx_version
 from sphinx.jinja2glue import BuiltinTemplateLoader
 from sphinx.util.osutil import os_path, relative_uri, ensuredir, copyfile
-from sphinx.builders.html import PickleHTMLBuilder
+from sphinxcontrib.serializinghtml import PickleHTMLBuilder
 
 from . import package_dir
 from .writer import WebSupportTranslator


### PR DESCRIPTION
Now PikcleHTMLBuilder has been provided by sphinxcontrib-serializinghtml
package.  So it should be imported from the package instead of
sphinx.builders.html.