### PR TITLE
Fix circular import in package init

### DIFF
--- a/sphinxcontrib/websupport/__init__.py
+++ b/sphinxcontrib/websupport/__init__.py
@@ -11,9 +11,9 @@
 """
 from os import path
 
-from sphinxcontrib.websupport.core import WebSupport  # NOQA
-
 __version__ = '1.2.5'
 __version_info__ = (1, 2, 5)
 
 package_dir = path.abspath(path.dirname(__file__))
+
+from sphinxcontrib.websupport.core import WebSupport  # NOQA


### PR DESCRIPTION
The `core.WebSupport` import depends on `package_dir`, so it needs to be done after that's defined. (That's why the line was `# noqa`-d to begin with.)

See https://github.com/sphinx-doc/sphinxcontrib-websupport/issues/57#issuecomment-1564137251
