### PR TITLE
Fix the failing CI, by replacing Python 3.5 & 3.6 with 3.10, 3.11, and 3.12-dev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, 3.10-dev]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12-dev]
       max-parallel: 1
 
     steps:

--- a/sphinxcontrib/websupport/builder.py
+++ b/sphinxcontrib/websupport/builder.py
@@ -27,7 +27,7 @@ from .utils import is_commentable
 
 if False:
     # For type annotation
-    from typing import Any, Dict, Iterable, Tuple  # NOQA
+    from typing import Any, Dict, Iterable, Optional, Tuple  # NOQA
     from docutils import nodes  # NOQA
     from sphinx.application import Sphinx  # NOQA
 
@@ -162,7 +162,7 @@ class WebSupportBuilder(PickleHTMLBuilder):
 
     def handle_page(self, pagename, addctx, templatename='page.html',
                     outfilename=None, event_arg=None):
-        # type: (str, Dict, str, str, Any) -> None
+        # type: (str, Dict, str, Optional[str], Any) -> None
         ctx, doc_ctx = self._render_page(pagename, addctx,
                                          templatename, event_arg)
 

--- a/tox.ini
+++ b/tox.ini
@@ -36,4 +36,4 @@ commands=
 extras =
     lint
 commands=
-    mypy sphinxcontrib/
+    mypy -p sphinxcontrib

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 2.4.0
 envlist=
-    py{35,36,37,38,39,310-dev},
+    py{37,38,39,310,311,312-dev},
     flake8
     mypy
 
@@ -12,7 +12,9 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
-    3.10: py310-dev
+    3.10: py310
+    3.11: py311
+    3.12: py312-dev
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
A second commit fixes the mypy failures by updating the `tox.ini` invocation, and adding an `Optional` wrapper that used to be implicit to one type comment.