### PR TITLE
Publish the optional extra `whoosh`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,6 @@ test = [
     "pytest",
     "sqlalchemy",
     "whoosh",
-    # greenlet is required by sqlalchemy; 3.12 only supported in 3.0.0a1+
-    "greenlet>=3.0.0a1; python_version >= '3.12'",
 ]
 lint = [
     "flake8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,8 @@ dynamic = ["version"]
 [project.optional-dependencies]
 test = [
     "pytest",
+]
+whoosh = [
     "sqlalchemy",
     "whoosh",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ isolated_build = True
 usedevelop = True
 extras =
     test
+    whoosh
 setenv =
     SPHINX_TEST_TEMPDIR = {envdir}/testbuild
     PYTHONDONTWRITEBYTECODE = true


### PR DESCRIPTION
The problem I try to solve: as a Fedora packager I'd like to recommend to the users of the package installation of `sqlalchemy` and `whoosh` with this package, but not `pytest`. That extra, called `whoosh`, is then declared in `tox.ini` making sure the deps are available in the environment in tests.
Additionally, I discovered that websupport doesn't work with sqlalchemy 2+, put a hotfix on that.